### PR TITLE
Remove unused plugin-specific PDB config code

### DIFF
--- a/AsaApi/Core/Private/Helpers.cpp
+++ b/AsaApi/Core/Private/Helpers.cpp
@@ -1,73 +1,7 @@
 #include "Helpers.h"
 
-#include <algorithm>
-#include <cctype>
-#include <locale>
-
 namespace API
 {
-	void MergePdbConfig(nlohmann::json& left, const nlohmann::json& right)
-	{
-		nlohmann::json pdb_config_result({});
-
-		pdb_config_result["structures"] = MergeStringArrays(left.value("structures", std::vector<std::string>{}),
-		                                                    right.value("structures", std::vector<std::string>{}));
-		pdb_config_result["functions"] = MergeStringArrays(left.value("functions", std::vector<std::string>{}),
-		                                                   right.value("functions", std::vector<std::string>{}));
-		pdb_config_result["globals"] = MergeStringArrays(left.value("globals", std::vector<std::string>{}),
-		                                                 right.value("globals", std::vector<std::string>{}));
-
-		left = pdb_config_result;
-	}
-
-	std::vector<std::string> MergeStringArrays(std::vector<std::string> first, std::vector<std::string> second)
-	{
-		std::vector<std::string> merged, unique;
-		std::sort(first.begin(), first.end());
-		std::sort(second.begin(), second.end());
-		std::set_union(
-			first.begin(),
-			first.end(),
-			second.begin(),
-			second.end(),
-			std::back_inserter(merged),
-			[](std::string s1, std::string s2)
-			{
-				return std::lexicographical_compare(
-					s1.begin(),
-					s1.end(),
-					s2.begin(),
-					s2.end(),
-					[](char c1, char c2)
-					{
-						return std::tolower(c1) < std::tolower(c2);
-					}
-				);
-			}
-		);
-
-		std::unique_copy(
-			merged.begin(),
-			merged.end(),
-			std::back_inserter(unique),
-			[](std::string s1, std::string s2)
-			{
-				return std::equal(
-					s1.begin(),
-					s1.end(),
-					s2.begin(),
-					s2.end(),
-					[](char c1, char c2)
-					{
-						return std::tolower(c1) == std::tolower(c2);
-					}
-				);
-			}
-		);
-
-		return unique;
-	}
-
 	/*std::string ReplaceString(std::string subject, const std::string& search, const std::string& replace)
 	{
 		size_t pos = 0;

--- a/AsaApi/Core/Private/Helpers.h
+++ b/AsaApi/Core/Private/Helpers.h
@@ -1,14 +1,9 @@
 #pragma once
 
-#include <vector>
-
-#include "json.hpp"
+#include <string>
 
 namespace API
 {
-	void MergePdbConfig(nlohmann::json& left, const nlohmann::json& right);
-	std::vector<std::string> MergeStringArrays(std::vector<std::string> first, std::vector<std::string> second);
-
 	__forceinline std::string ReplaceString(std::string subject, const std::string& search, const std::string& replace)
 	{
 		size_t pos = 0;

--- a/AsaApi/Core/Private/PluginManager/PluginManager.cpp
+++ b/AsaApi/Core/Private/PluginManager/PluginManager.cpp
@@ -7,7 +7,6 @@
 #include <Logger/Logger.h>
 #include "Tools.h"
 
-#include "../Helpers.h"
 #include "../IBaseApi.h"
 #include <Timer.h>
 
@@ -17,57 +16,6 @@ namespace API
 	{
 		static PluginManager instance;
 		return instance;
-	}
-
-	nlohmann::json PluginManager::GetAllPDBConfigs()
-	{
-		namespace fs = std::filesystem;
-
-		const std::string dir_path = Tools::GetCurrentDir() + "/" + game_api->GetApiName() + "/Plugins";
-
-		auto result = nlohmann::json({});
-
-		for (const auto& dir_name : fs::directory_iterator(dir_path))
-		{
-			const auto& path = dir_name.path();
-			const auto filename = path.filename().stem().generic_string();
-
-			try
-			{
-				const auto plugin_pdb_config = ReadPluginPDBConfig(filename);
-				MergePdbConfig(result, plugin_pdb_config);
-			}
-			catch (const std::exception& error)
-			{
-				Log::GetLog()->warn("({}) {}", __FUNCTION__, error.what());
-			}
-		}
-
-		return result;
-	}
-
-	nlohmann::json PluginManager::ReadPluginPDBConfig(const std::string& plugin_name)
-	{
-		namespace fs = std::filesystem;
-
-		auto plugin_pdb_config = nlohmann::json({});
-
-		const std::string dir_path = Tools::GetCurrentDir() + "/" + game_api->GetApiName() + "/Plugins/" + plugin_name;
-		const std::string config_path = dir_path + "/PdbConfig.json";
-
-		if (!fs::exists(config_path))
-		{
-			return plugin_pdb_config;
-		}
-
-		std::ifstream file{ config_path };
-		if (file.is_open())
-		{
-			file >> plugin_pdb_config;
-			file.close();
-		}
-
-		return plugin_pdb_config;
 	}
 
 	nlohmann::json PluginManager::ReadSettingsConfig()

--- a/AsaApi/Core/Private/PluginManager/PluginManager.h
+++ b/AsaApi/Core/Private/PluginManager/PluginManager.h
@@ -46,11 +46,6 @@ namespace API
 		PluginManager& operator=(PluginManager&&) = delete;
 
 		/**
-		* \brief Get all plugin pdb configs
-		*/
-		static nlohmann::json GetAllPDBConfigs();
-
-		/**
 		 * \brief Find and load all plugins
 		 */
 		void LoadAllPlugins();
@@ -89,7 +84,6 @@ namespace API
 		~PluginManager() = default;
 
 		static nlohmann::json ReadPluginInfo(const std::string& plugin_name);
-		static nlohmann::json ReadPluginPDBConfig(const std::string& plugin_name);
 		static nlohmann::json ReadSettingsConfig();
 
 		void CheckPluginsDependencies();


### PR DESCRIPTION
There was a time when the ASE ArkServerApi provided offsets from the PDB for only specific structures. ArkServerApi allowed plugins to provide a config file specifying additional structures they needed offsets for. ArkServerApi was modified to cache offsets for all structures, but some code related to plugin-specific PDB configs remained in the codebase unused. This change removes that unused code.

Note: I'm not sure what the plan is for the `ReplaceString()` function and `Helpers.cpp`. The function is now defined in `Helpers.h` and the only thing remaining in `Helpers.cpp` (as of this PR) is the old function definition commented out. I can remove `Helpers.cpp` altogether if the dev team wants.