### PR TITLE
Remove deprecated AsaApi::Tools functions

### DIFF
--- a/AsaApi/Core/Private/Tools/Tools.cpp
+++ b/AsaApi/Core/Private/Tools/Tools.cpp
@@ -15,32 +15,6 @@ namespace AsaApi::Tools
 		return std::string(buffer).substr(0, pos);
 	}
 
-	[[deprecated]] std::wstring ConvertToWideStr(const std::string& text)
-	{
-		const size_t size = text.size();
-
-		std::wstring wstr;
-		if (size > 0)
-		{
-			wstr.resize(size);
-
-			size_t converted_chars;
-			mbstowcs_s(&converted_chars, wstr.data(), size + 1, text.c_str(), _TRUNCATE);
-		}
-
-		return wstr;
-	}
-
-	[[deprecated]] std::string ConvertToAnsiStr(const std::wstring& text)
-	{
-		const size_t length = text.size();
-
-		std::string str(length, '\0');
-		std::use_facet<std::ctype<wchar_t>>(std::locale()).narrow(text.c_str(), text.c_str() + length, '?', str.data());
-
-		return str;
-	}
-
 	std::string Utf8Encode(const std::wstring& wstr)
 	{
 		std::string converted_string;

--- a/AsaApi/Core/Public/Tools.h
+++ b/AsaApi/Core/Public/Tools.h
@@ -8,9 +8,6 @@ namespace AsaApi::Tools
 {
 	ARK_API std::string GetCurrentDir();
 
-	[[deprecated]] ARK_API std::wstring ConvertToWideStr(const std::string& text);
-	[[deprecated]] ARK_API std::string ConvertToAnsiStr(const std::wstring& text);
-
 	/**
 	 * \brief Converts a wide Unicode string to an UTF8 string
 	 */


### PR DESCRIPTION
Remove the ConvertToWideStr() and ConvertToAnsiStr() functions in the AsaApi::Tools namespace. These functions are exported by AsaApi.dll, but are marked as deprecated in the Public headers and their removal is unlikely to break existing ASA plugin builds.