### PR TITLE
ServerID Fix + Header change

### DIFF
--- a/AsaApi/AsaApi.vcxproj
+++ b/AsaApi/AsaApi.vcxproj
@@ -345,7 +345,7 @@ copy  /Y "$(SolutionDir)AsaApi\Core\Private\PDBReader\pdbignores.txt" "E:\ASA\Te
     <PostBuildEvent>
       <Command>xcopy /I  /Y "$(TargetDir)$(ProjectName).lib" "$(SolutionDir)out_lib\"
 xcopy /I  /Y "$(TargetDir)$(ProjectName).lib" "$(SolutionDir)..\ARK-API-Stable-Libs\"
-xcopy /I  /Y "$(TargetDir)$(ProjectName).lib" "$(SolutionDir)..\ARK-API-Stable-Libs\1.00\"
+xcopy /I  /Y "$(TargetDir)$(ProjectName).lib" "$(SolutionDir)..\ARK-API-Stable-Libs\1.01\"
 
 copy "$(SolutionDir)$(PlatformName)\$(ConfigurationName)\$(ProjectName).dll" "F:\ASA-Dedicated\asa-server\ShooterGame\Binaries\Win64\ArkApi\" /y
 copy "$(SolutionDir)$(PlatformName)\$(ConfigurationName)\$(ProjectName).pdb" "F:\ASA-Dedicated\asa-server\ShooterGame\Binaries\Win64\ArkApi\" /y</Command>

--- a/AsaApi/Core/Private/Ark/ArkBaseApi.cpp
+++ b/AsaApi/Core/Private/Ark/ArkBaseApi.cpp
@@ -13,7 +13,7 @@
 
 namespace API
 {
-	constexpr float api_version = 1.01;
+	constexpr float api_version = 1.02;
 
 	ArkBaseApi::ArkBaseApi()
 		: commands_(std::make_unique<AsaApi::Commands>()),

--- a/AsaApi/Core/Private/Ark/HooksImpl.cpp
+++ b/AsaApi/Core/Private/Ark/HooksImpl.cpp
@@ -95,7 +95,7 @@ namespace AsaApi
 		for (auto actor : actors)
 		{
 			FString bp = AsaApi::GetApiUtils().GetBlueprint(actor);
-			if (bp.Equals("Blueprint'/Script/ShooterGame.Default__PrimalPersistentWorldData'"))
+			if (bp.Equals("Blueprint'/Script/ShooterGame.PrimalPersistentWorldData'"))
 			{
 				if (actor->TargetingTeamField() == 0)
 					actor->TargetingTeamField() = a_shooter_game_mode->ServerIDField();

--- a/AsaApi/Core/Public/API/ARK/UE.h
+++ b/AsaApi/Core/Public/API/ARK/UE.h
@@ -959,18 +959,9 @@ struct Globals
 			ObjectClass, InOuter, InName, Filename, LoadFlags, Sandbox, bAllowObjectReconciliation, nullptr);
 	}
 
-	static UObject* StaticConstructObject(UClass* InClass, UObject* InOuter, FName InName, EObjectFlags InFlags, UObject* InTemplate, bool bCopyTransientsFromClassDefaults, FObjectInstancingGraph* InInstanceGraph)
+	static UObject* StaticConstructObject(FStaticConstructObjectParameters& Params)
 	{
-		FStaticConstructObjectParameters Params;
-		Params.Class = InClass;
-		Params.Outer = InOuter;
-		Params.Name = InName;
-		Params.SetFlags = InFlags;
-		Params.Template = InTemplate;
-		Params.bCopyTransientsFromClassDefaults = bCopyTransientsFromClassDefaults;
-		Params.InstanceGraph = InInstanceGraph;
-
-		return NativeCall<UObject*, FStaticConstructObjectParameters*>(nullptr, "Global.StaticConstructObject_Internal(FStaticConstructObjectParameters&)", &Params);
+		return NativeCall<UObject*, FStaticConstructObjectParameters&>(nullptr, "Global.StaticConstructObject_Internal(FStaticConstructObjectParameters&)", Params);
 	}
 
 	static DataValue<struct UEngine*> GEngine() { return { "Global.GEngine" }; }


### PR DESCRIPTION
Updated StaticConstructObject to match the internal paramaters.

Fixed ServerID breakage caused by the correction to the GetBlueprint update.

Version bump 1.02