### PR TITLE
Remove unused DllMain()

### DIFF
--- a/AsaApi/main.cpp
+++ b/AsaApi/main.cpp
@@ -86,24 +86,3 @@ extern "C" ARK_API void InitApi()
 {
 	Init();
 }
-
-void Unload()
-{
-}
-
-BOOL APIENTRY DllMain(HMODULE hModule,
-	DWORD  ul_reason_for_call,
-	LPVOID lpReserved
-)
-{
-	switch (ul_reason_for_call)
-	{
-	case DLL_PROCESS_ATTACH:
-	case DLL_THREAD_ATTACH:
-	case DLL_THREAD_DETACH:
-	case DLL_PROCESS_DETACH:
-		Unload();
-		break;
-	}
-	return TRUE;
-}


### PR DESCRIPTION
Remove `DllMain()`. It is no longer used now that `InitApi()` is exported to initialize the AsaApi.

If the dev team prefers to keep `DllMain()` around, I'd like to at least defensively clean up the switch so that all cases don't fall through to call `Unload()`.

This change was discussed on the GSH Discord.