### PR TITLE
Return 0 from GetPlayerID() on failure

### DIFF
--- a/AsaApi/Core/Public/Ark/ArkApiUtils.h
+++ b/AsaApi/Core/Public/Ark/ArkApiUtils.h
@@ -569,7 +569,7 @@ namespace AsaApi
 			auto* shooter_character = static_cast<AShooterCharacter*>(character);
 			return shooter_character != nullptr && shooter_character->GetPlayerData() != nullptr
 				? shooter_character->GetPlayerData()->MyDataField()->PlayerDataIDField()
-				: -1;
+				: 0;
 		}
 
 		static FORCEINLINE uint64 GetPlayerID(AController* controller)


### PR DESCRIPTION
`uint64 IApiUtils::GetPlayerID(APrimalCharacter* character)` currently returns `-1` on failure. Change to return `0` on failure for easier error checking on the unsigned return and for consistency with `uint64 IApiUtils::GetPlayerID(AController* controller)`.

This suggestion was raised by Kal on the GSH Discord.