### PR TITLE
Header Updates

### DIFF
--- a/AsaApi/AsaApi.vcxproj
+++ b/AsaApi/AsaApi.vcxproj
@@ -345,7 +345,7 @@ copy  /Y "$(SolutionDir)AsaApi\Core\Private\PDBReader\pdbignores.txt" "E:\ASA\Te
     <PostBuildEvent>
       <Command>xcopy /I  /Y "$(TargetDir)$(ProjectName).lib" "$(SolutionDir)out_lib\"
 xcopy /I  /Y "$(TargetDir)$(ProjectName).lib" "$(SolutionDir)..\ARK-API-Stable-Libs\"
-xcopy /I  /Y "$(TargetDir)$(ProjectName).lib" "$(SolutionDir)..\ARK-API-Stable-Libs\1.01\"
+xcopy /I  /Y "$(TargetDir)$(ProjectName).lib" "$(SolutionDir)..\ARK-API-Stable-Libs\1.02\"
 
 copy "$(SolutionDir)$(PlatformName)\$(ConfigurationName)\$(ProjectName).dll" "F:\ASA-Dedicated\asa-server\ShooterGame\Binaries\Win64\ArkApi\" /y
 copy "$(SolutionDir)$(PlatformName)\$(ConfigurationName)\$(ProjectName).pdb" "F:\ASA-Dedicated\asa-server\ShooterGame\Binaries\Win64\ArkApi\" /y</Command>

--- a/AsaApi/Core/Public/API/ARK/Actor.h
+++ b/AsaApi/Core/Public/API/ARK/Actor.h
@@ -40,6 +40,22 @@ struct FPrimalChatMessage {
 
 struct FPrimalPlayerCharacterConfigStructReplicated
 {
+    unsigned __int8 bIsFemale : 1;
+    FLinearColor BodyColors[4];
+    FString PlayerCharacterName;
+    unsigned __int8 FacialHairIndex;
+    unsigned __int8 HeadHairIndex;
+    unsigned __int8 EyebrowIndex;
+    float PercentOfFullHeadHairGrowth;
+    float PercentOfFullFacialHairGrowth;
+    float RawBoneModifiers[26];
+    int PlayerSpawnRegionIndex;
+    unsigned __int8 OverrideHeadHairColor[2];
+    unsigned __int8 OverrideFacialHairColor[2];
+    unsigned __int8 DynamicMaterialBytes[50];
+    int PlayerVoiceCollectionIndex;
+    unsigned __int8 bUsingCustomPlayerVoiceCollection : 1;
+
     // Fields
 
     FieldArray<FLinearColor, 4> BodyColorsField() { return { this, "FPrimalPlayerCharacterConfigStructReplicated.BodyColors" }; }
@@ -56,8 +72,8 @@ struct FPrimalPlayerCharacterConfigStructReplicated
 
     // Bitfields
 
-    BitFieldValue<bool, unsigned __int32> bIsFemale() { return { this, "FPrimalPlayerCharacterConfigStructReplicated.bIsFemale" }; }
-    BitFieldValue<bool, unsigned __int32> bUsingCustomPlayerVoiceCollection() { return { this, "FPrimalPlayerCharacterConfigStructReplicated.bUsingCustomPlayerVoiceCollection" }; }
+    BitFieldValue<bool, unsigned __int32> bIsFemaleField() { return { this, "FPrimalPlayerCharacterConfigStructReplicated.bIsFemale" }; }
+    BitFieldValue<bool, unsigned __int32> bUsingCustomPlayerVoiceCollectionField() { return { this, "FPrimalPlayerCharacterConfigStructReplicated.bUsingCustomPlayerVoiceCollection" }; }
 
     // Functions
 
@@ -70,6 +86,30 @@ struct FPrimalPlayerCharacterConfigStructReplicated
     FPrimalPlayerCharacterConfigStruct* GetPlayerCharacterConfig(FPrimalPlayerCharacterConfigStruct* result) { return NativeCall<FPrimalPlayerCharacterConfigStruct*, FPrimalPlayerCharacterConfigStruct*>(this, "FPrimalPlayerCharacterConfigStructReplicated.GetPlayerCharacterConfig()", result); }
     //void FPrimalPlayerCharacterConfigStructReplicated(const FPrimalPlayerCharacterConfigStruct* fromConfig) { NativeCall<void, const FPrimalPlayerCharacterConfigStruct*>(this, "FPrimalPlayerCharacterConfigStructReplicated.FPrimalPlayerCharacterConfigStructReplicated(FPrimalPlayerCharacterConfigStruct&)", fromConfig); }
 };
+
+struct UDamageType : UObject
+{
+    // Fields
+
+    float& DamageImpulseField() { return *GetNativePointerField<float*>(this, "UDamageType.DamageImpulse"); }
+    float& DestructibleImpulseField() { return *GetNativePointerField<float*>(this, "UDamageType.DestructibleImpulse"); }
+    float& DestructibleDamageSpreadScaleField() { return *GetNativePointerField<float*>(this, "UDamageType.DestructibleDamageSpreadScale"); }
+    float& DamageFalloffField() { return *GetNativePointerField<float*>(this, "UDamageType.DamageFalloff"); }
+
+    // Bitfields
+
+    BitFieldValue<bool, unsigned __int32> bIsPassiveDamage() { return { this, "UDamageType.bIsPassiveDamage" }; }
+    BitFieldValue<bool, unsigned __int32> bCausedByWorld() { return { this, "UDamageType.bCausedByWorld" }; }
+    BitFieldValue<bool, unsigned __int32> bScaleMomentumByMass() { return { this, "UDamageType.bScaleMomentumByMass" }; }
+    BitFieldValue<bool, unsigned __int32> bRadialDamageVelChange() { return { this, "UDamageType.bRadialDamageVelChange" }; }
+
+    // Functions
+
+    static UClass* StaticClass() { return NativeCall<UClass*>(nullptr, "UDamageType.StaticClass()"); }
+    //void UDamageType(const FObjectInitializer* ObjectInitializer) { NativeCall<void, const FObjectInitializer*>(this, "UDamageType.UDamageType(FObjectInitializer&)", ObjectInitializer); }
+};
+
+
 
 struct UPrimalActor : UObject
 {

--- a/AsaApi/Core/Public/API/ARK/Other.h
+++ b/AsaApi/Core/Public/API/ARK/Other.h
@@ -2564,3 +2564,40 @@ struct FUniqueNetIdEOS : FUniqueNetId
 	static const TSharedRef<FUniqueNetIdEOS const>* DedicatedServerId() { return NativeCall<const TSharedRef<FUniqueNetIdEOS const> *>(nullptr, "FUniqueNetIdEOS.DedicatedServerId()"); }
 };
 
+struct FCharacterAndControllerPair
+{
+	// Fields
+
+	AShooterCharacter*& CharacterField() { return *GetNativePointerField<AShooterCharacter**>(this, "FCharacterAndControllerPair.Character"); }
+	AShooterPlayerController*& ControllerField() { return *GetNativePointerField<AShooterPlayerController**>(this, "FCharacterAndControllerPair.Controller"); }
+
+	// Bitfields
+
+
+	// Functions
+
+	static UScriptStruct* StaticStruct() { return NativeCall<UScriptStruct*>(nullptr, "FCharacterAndControllerPair.StaticStruct()"); }
+};
+
+struct FPointDamageEvent : FDamageEvent
+{
+	// Fields
+
+	float& DamageField() { return *GetNativePointerField<float*>(this, "FPointDamageEvent.Damage"); }
+	FVector_NetQuantizeNormal& ShotDirectionField() { return *GetNativePointerField<FVector_NetQuantizeNormal*>(this, "FPointDamageEvent.ShotDirection"); }
+	FHitResult& HitInfoField() { return *GetNativePointerField<FHitResult*>(this, "FPointDamageEvent.HitInfo"); }
+
+	// Bitfields
+
+
+	// Functions
+
+	//void ~FPointDamageEvent() { NativeCall<void>(this, "FPointDamageEvent.~FPointDamageEvent()"); }
+	//void FPointDamageEvent(const FPointDamageEvent* __that) { NativeCall<void, const FPointDamageEvent*>(this, "FPointDamageEvent.FPointDamageEvent(FPointDamageEvent&)", __that); }
+	bool IsOfType(int InID) { return NativeCall<bool, int>(this, "FPointDamageEvent.IsOfType(int)", InID); }
+	//void FPointDamageEvent() { NativeCall<void>(this, "FPointDamageEvent.FPointDamageEvent()"); }
+	//void FPointDamageEvent(float InDamage, const FHitResult* InHitInfo, const UE::Math::TVector<double>* InShotDirection, TSubclassOf<UDamageType> InDamageTypeClass) { NativeCall<void, float, const FHitResult*, const UE::Math::TVector<double>*, TSubclassOf<UDamageType>>(this, "FPointDamageEvent.FPointDamageEvent(float,FHitResult&,UE::Math::TVector<double>&,TSubclassOf<UDamageType>)", InDamage, InHitInfo, InShotDirection, InDamageTypeClass); }
+	static UScriptStruct* StaticStruct() { return NativeCall<UScriptStruct*>(nullptr, "FPointDamageEvent.StaticStruct()"); }
+	void GetBestHitInfo(const AActor* HitActor, const AActor* HitInstigator, FHitResult* OutHitInfo, UE::Math::TVector<double>* OutImpulseDir) { NativeCall<void, const AActor*, const AActor*, FHitResult*, UE::Math::TVector<double>*>(this, "FPointDamageEvent.GetBestHitInfo(AActor*,AActor*,FHitResult&,UE::Math::TVector<double>&)", HitActor, HitInstigator, OutHitInfo, OutImpulseDir); }
+};
+

--- a/AsaApi/Core/Public/API/UE/Containers/UnrealString.h
+++ b/AsaApi/Core/Public/API/UE/Containers/UnrealString.h
@@ -1833,7 +1833,10 @@ public:
 	 * Removes whitespace characters from the start and end of this string.
 	 * @note Unlike Trim() this function returns a copy, and does not mutate the string.
 	 */
-	UE_NODISCARD FString TrimStartAndEnd() const &;
+	UE_NODISCARD FString TrimStartAndEnd() const&
+	{
+		return NativeCall<FString>(this, "FString.TrimStartAndEnd()");
+	}
 
 	/**
 	 * Removes whitespace characters from the start and end of this string.
@@ -2174,7 +2177,10 @@ public:
 	 *
 	 * @param	Chars	by default, replaces all supported characters; this parameter allows you to limit the replacement to a subset.
 	 */
-	void ReplaceCharWithEscapedCharInline( const TArray<TCHAR>* Chars = nullptr );
+	void ReplaceCharWithEscapedCharInline( const TArray<TCHAR>* Chars = nullptr )
+	{
+		NativeCall<void, const TArray<TCHAR>*>(this, "FString.ReplaceCharWithEscapedCharInline(TArray<wchar_t,TSizedDefaultAllocator<32>>*)", Chars);
+	}
 
 	/**
 	 * Replaces certain characters with the "escaped" version of that character (i.e. replaces "\n" with "\\n").

--- a/AsaApi/Core/Public/API/UE/UObject/NameTypes.h
+++ b/AsaApi/Core/Public/API/UE/UObject/NameTypes.h
@@ -110,7 +110,10 @@ private:
 	{
 		return NativeCall<FNameEntryId, EName>(nullptr, "FNameEntryId.FromValidEName(EName)", Ename);
 	}
-	static FNameEntryId FromValidENamePostInit(EName Ename);
+	static FNameEntryId FromValidENamePostInit(EName Ename)
+	{
+		return NativeCall<FNameEntryId, EName>(nullptr, "FNameEntryId.FromValidEName(EName)", Ename);
+	}
 
 public:
 	friend inline bool operator==(EName Ename, FNameEntryId Id) { return Id == Ename; }


### PR DESCRIPTION
The most significant changes include the update to the post-build event command in `AsaApi.vcxproj`, the extension of the `FPrimalChatMessage` struct in `Actor.h`, and the addition of new structs in `Actor.h` and `Other.h`. The `FPrimalPlayerCharacterConfigStructReplicated` struct in `Actor.h` has also been updated, and the `TrimStartAndEnd` and `ReplaceCharWithEscapedCharInline` functions in `UnrealString.h` and the `FromValidENamePostInit` function in `NameTypes.h` have been updated to include their implementation inline.

1. 1. The post-build event command in `AsaApi.vcxproj` has been updated to copy the project library to a different directory in the ARK-API-Stable-Libs folder (from version 1.01 to 1.02).
2. The `FPrimalChatMessage` struct in `Actor.h` has been extended with several new fields related to player character configuration.
3. The `FPrimalPlayerCharacterConfigStructReplicated` struct in `Actor.h` has been updated to rename the `bIsFemale` and `bUsingCustomPlayerVoiceCollection` bitfields to `bIsFemaleField` and `bUsingCustomPlayerVoiceCollectionField` respectively.
4. A new `UDamageType` struct has been added to `Actor.h`, with fields for damage impulse, destructible impulse, destructible damage spread scale, damage falloff, and bitfields for passive damage, world-caused damage, mass-scaled momentum, and radial damage velocity change.
5. Two new structs have been added to `Other.h`: `FCharacterAndControllerPair` and `FPointDamageEvent`.
6. The `TrimStartAndEnd` and `ReplaceCharWithEscapedCharInline` functions in `UnrealString.h` and the `FromValidENamePostInit` function in `NameTypes.h` have been updated to include their implementation inline.