### PR TITLE
http timeout response logging solution

### DIFF
--- a/AsaApi/Core/Private/Tools/Requests.cpp
+++ b/AsaApi/Core/Private/Tools/Requests.cpp
@@ -155,7 +155,7 @@ namespace API
 				}
 				catch (const Poco::Exception& exc)
 				{
-					Log::GetLog()->error(exc.displayText());
+					Result = exc.displayText();
 				}
 
 				const bool success = (int)response.getStatus() >= 200
@@ -193,7 +193,7 @@ namespace API
 				}
 				catch (const Poco::Exception& exc)
 				{
-					Log::GetLog()->error(exc.displayText());
+					Result = exc.displayText();
 				}
 
 				const bool success = (int)response.getStatus() >= 200
@@ -231,7 +231,7 @@ namespace API
 				}
 				catch (const Poco::Exception& exc)
 				{
-					Log::GetLog()->error(exc.displayText());
+					Result = exc.displayText();
 				}
 
 				const bool success = (int)response.getStatus() >= 200
@@ -285,7 +285,7 @@ namespace API
 				}
 				catch (const Poco::Exception& exc)
 				{
-					Log::GetLog()->error(exc.displayText());
+					Result = exc.displayText();
 				}
 
 				const bool success = (int)response.getStatus() >= 200
@@ -318,7 +318,7 @@ namespace API
 				}
 				catch (const Poco::Exception& exc)
 				{
-					Log::GetLog()->error(exc.displayText());
+					Result = exc.displayText();
 				}
 
 				const bool success = (int)response.getStatus() >= 200


### PR DESCRIPTION
- redirecting the logs to the `Result`so that user can have more control handling timeouts or even real errors


- tried usecase when performing `CreateGetRequest` realtime sometimes it return `No Message received` means timeout it will flood the console everytime the connection timeout so instead logging it directly, sending the `exc.displayText();` to `Result` variable for the callback have a result string if success bool fails then the user has more control parsing these responses either to log or throw the exception `if success == 0 && res!=""`

![image](https://github.com/ServersHub/ServerAPI/assets/6821381/14f0dc41-eea7-4983-8e44-01b0efad0669)