### PR TITLE
GetEOSIDForPlayerID change to avoid potential garbage Eos_ID's being inserted in game memory and add missing fields in headers

### DIFF
--- a/AsaApi/Core/Public/API/ARK/Actor.h
+++ b/AsaApi/Core/Public/API/ARK/Actor.h
@@ -3161,6 +3161,7 @@ struct AShooterPlayerController : ABasePlayerController
 
     //void ClientPlayForceFeedback(UForceFeedbackEffect* ForceFeedbackEffect, FForceFeedbackParameters* Params, float intensityMult) { NativeCall<void, UForceFeedbackEffect*, FForceFeedbackParameters*, float>(this, "AShooterPlayerController.ClientPlayForceFeedback(UForceFeedbackEffect*,FForceFeedbackParameters,float)", ForceFeedbackEffect, Params, intensityMult); }
     static UClass* GetPrivateStaticClass() { return NativeCall<UClass*>(nullptr, "AShooterPlayerController.GetPrivateStaticClass()"); }
+    static UClass* StaticClass() { return NativeCall<UClass*>(nullptr, "AShooterPlayerController.StaticClass()"); }
     bool AllowedToSpectateAllTeams() { return NativeCall<bool>(this, "AShooterPlayerController.AllowedToSpectateAllTeams()"); }
     void BPGetExtraWaypointsSOTF(APlayerController* Controller, AShooterCharacter* PlayerPawn, const TArray<FPointOfInterestData_ForCompanion, TSizedDefaultAllocator<32> >* IndicatorsIn, TArray<FPointOfInterestData_ForCompanion, TSizedDefaultAllocator<32> >* IndicatorsOut) { NativeCall<void, APlayerController*, AShooterCharacter*, const TArray<FPointOfInterestData_ForCompanion, TSizedDefaultAllocator<32> >*, TArray<FPointOfInterestData_ForCompanion, TSizedDefaultAllocator<32> >*>(this, "AShooterPlayerController.BPGetExtraWaypointsSOTF(APlayerController*,AShooterCharacter*,TArray<FPointOfInterestData_ForCompanion,TSizedDefaultAllocator<32>>&,TArray<FPointOfInterestData_ForCompanion,TSizedDefaultAllocator<32>>&)", Controller, PlayerPawn, IndicatorsIn, IndicatorsOut); }
     bool BPPreventChangeCamera() { return NativeCall<bool>(this, "AShooterPlayerController.BPPreventChangeCamera()"); }
@@ -7382,6 +7383,7 @@ struct APrimalDinoCharacter : APrimalCharacter
     bool AllowPushOthers() { return NativeCall<bool>(this, "APrimalDinoCharacter.AllowPushOthers()"); }
     bool FlyingUseHighQualityCollision() { return NativeCall<bool>(this, "APrimalDinoCharacter.FlyingUseHighQualityCollision()"); }
     static UClass* GetPrivateStaticClass() { return NativeCall<UClass*>(nullptr, "APrimalDinoCharacter.GetPrivateStaticClass()"); }
+    static UClass* StaticClass() { return NativeCall<UClass*>(nullptr, "APrimalDinoCharacter.StaticClass()"); }
     bool AllowWakingTame(APlayerController* ForPC) { return NativeCall<bool, APlayerController*>(this, "APrimalDinoCharacter.AllowWakingTame(APlayerController*)", ForPC); }
     float BlueprintAdjustOutputDamage(int AttackIndex, float OriginalDamageAmount, AActor* HitActor, TSubclassOf<UDamageType>* OutDamageType, float* OutDamageImpulse) { return NativeCall<float, int, float, AActor*, TSubclassOf<UDamageType>*, float*>(this, "APrimalDinoCharacter.BlueprintAdjustOutputDamage(int,float,AActor*,TSubclassOf<UDamageType>&,float&)", AttackIndex, OriginalDamageAmount, HitActor, OutDamageType, OutDamageImpulse); }
     float BlueprintExtraBabyScaling() { return NativeCall<float>(this, "APrimalDinoCharacter.BlueprintExtraBabyScaling()"); }

--- a/AsaApi/Core/Public/API/ARK/GameMode.h
+++ b/AsaApi/Core/Public/API/ARK/GameMode.h
@@ -2239,6 +2239,7 @@ struct AShooterGameMode : APrimalGameMode
 	//TArray<AShooterGameMode::FAutoWaterRefreshCropData, TSizedDefaultAllocator<32> >& AutoWaterRefreshCropQueueField() { return *GetNativePointerField<TArray<AShooterGameMode::FAutoWaterRefreshCropData, TSizedDefaultAllocator<32> >*>(this, "AShooterGameMode.AutoWaterRefreshCropQueue"); }
 	FString& CachedSaveDirectoryOverrideField() { return *GetNativePointerField<FString*>(this, "AShooterGameMode.CachedSaveDirectoryOverride"); }
 	int& TicksUntilRegisterField() { return *GetNativePointerField<int*>(this, "AShooterGameMode.TicksUntilRegister"); }
+	bool& bDisableStructurePlacementCollisionField() { return *GetNativePointerField<bool*>(this, "AShooterGameMode.bDisableStructurePlacementCollision"); }
 
 	// Bitfields
 

--- a/AsaApi/Core/Public/API/ARK/PrimalStructure.h
+++ b/AsaApi/Core/Public/API/ARK/PrimalStructure.h
@@ -2138,6 +2138,7 @@ struct APrimalStructureTurret : APrimalStructureItemContainer
     // Functions
 
     static UClass* GetPrivateStaticClass() { return NativeCall<UClass*>(nullptr, "APrimalStructureTurret.GetPrivateStaticClass()"); }
+    static UClass* StaticClass() { return NativeCall<UClass*>(nullptr, "APrimalStructureTurret.StaticClass()"); }
     static void StaticRegisterNativesAPrimalStructureTurret() { NativeCall<void>(nullptr, "APrimalStructureTurret.StaticRegisterNativesAPrimalStructureTurret()"); }
     void ValidateGeneratedRepEnums(const TArray<FRepRecord, TSizedDefaultAllocator<32> >* ClassReps) { NativeCall<void, const TArray<FRepRecord, TSizedDefaultAllocator<32> >*>(this, "APrimalStructureTurret.ValidateGeneratedRepEnums(TArray<FRepRecord,TSizedDefaultAllocator<32>>&)", ClassReps); }
     void DrawHUD(AShooterHUD* HUD) { NativeCall<void, AShooterHUD*>(this, "APrimalStructureTurret.DrawHUD(AShooterHUD*)", HUD); }

--- a/AsaApi/Core/Public/Ark/ArkApiUtils.h
+++ b/AsaApi/Core/Public/Ark/ArkApiUtils.h
@@ -581,6 +581,12 @@ namespace AsaApi
 		FORCEINLINE const FString GetEOSIDForPlayerID(int player_id)
 		{
 			FString eos_id;
+
+			if (player_id == 0)
+			{
+				return eos_id;
+			}
+
 			GetShooterGameMode()->GetSteamIDStringForPlayerID(&eos_id, player_id);
 			if (eos_id.IsEmpty())
 			{
@@ -595,7 +601,10 @@ namespace AsaApi
 					}
 				}
 
-				GetShooterGameMode()->AddPlayerID(player_id, &eos_id, false);
+				if (!eos_id.IsEmpty())
+				{
+					GetShooterGameMode()->AddPlayerID(player_id, &eos_id, false);
+				}
 			}
 
 			return eos_id;


### PR DESCRIPTION
-change GetEOSIDForPlayerID so that potentially invalid eos-id's may not be inserted into game memory
-added bDisableStructurePlacementCollisionField in AShooterGameMode
-added missing StaticClass functions for classes